### PR TITLE
Performance test reintroduced + release buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+.swiftpm
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FileTools",
     platforms: [
-        .macOS("10.15"),
+        .macOS(.v11),
         .iOS(.v13)
     ],
     products: [

--- a/Sources/FileTools/FileTools.swift
+++ b/Sources/FileTools/FileTools.swift
@@ -19,7 +19,6 @@ class LinePublisherSubscription<S: Subscriber>: Subscription where S.Input == St
     var cap: Int = 0
     var readLines = 0
 
-
     init(url: URL, linesToRead: Int?, subscriber: S) {
         self.url = url
         self.linesToRead = linesToRead
@@ -68,9 +67,11 @@ class LinePublisherSubscription<S: Subscriber>: Subscription where S.Input == St
 
     func cancel() {
         subscriber = nil
-        if let _ = filePointer {
-            fclose(filePointer)
-        }
+    }
+
+    deinit {
+        free(buffer)
+        fclose(filePointer)
     }
 }
 


### PR DESCRIPTION
Delete and ignore .swiftpm directory

Cleaning

deallocate buffer

deallocate the buffer when the publisher gets cancelled.

cancel() bugfix

cancel was potentially called multiple times

bugfix release pointers

better understanding of whats happening